### PR TITLE
use IntEnum which is more convinient for integration

### DIFF
--- a/fuocore/models.py
+++ b/fuocore/models.py
@@ -7,10 +7,10 @@ fuocore.model
 这个模块对音乐相关模型进行了定义，声明了各模型的属性。
 """
 
-from enum import Enum
+from enum import IntEnum
 
 
-class ModelType(Enum):
+class ModelType(IntEnum):
     dummy = 0
 
     song = 1

--- a/fuocore/player.py
+++ b/fuocore/player.py
@@ -19,7 +19,7 @@
  """
 
 from abc import ABCMeta, abstractmethod
-from enum import Enum
+from enum import IntEnum
 import logging
 import random
 
@@ -32,7 +32,7 @@ from fuocore.dispatch import Signal
 logger = logging.getLogger(__name__)
 
 
-class State(Enum):
+class State(IntEnum):
     """
     播放器的状态
     """
@@ -41,7 +41,7 @@ class State(Enum):
     playing = 2
 
 
-class PlaybackMode(Enum):
+class PlaybackMode(IntEnum):
     """
     播放列表的歌曲播放顺序
     """


### PR DESCRIPTION
Enum is bad for integration with other programs.
See: https://docs.python.org/3/library/enum.html#comparisons

在调试的时候，我们想改变 Player 的状态，直接的想法是： `player.state = 3`
而之前使用 Enum 的话，就不能这么直接的完成，需要 `player.state = State.xxx`

在真正的代码中，更推荐使用后者，但是在调试时，前者方便许多，所以将 Enum 改成  IntEnum