### PR TITLE
set up missing submodule fuocore.xiami

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'fuocore',
         'fuocore.local',
         'fuocore.netease',
+        'fuocore.xiami',
         'fuocore.qqmusic',
         'fuocore.protocol',
         'fuocore.protocol.handlers',


### PR DESCRIPTION
`fuocore.main` can't work after installation because of missing sub module `fuocore.xiami` in `setup.py`.